### PR TITLE
fix request bug

### DIFF
--- a/happn/happn.py
+++ b/happn/happn.py
@@ -125,7 +125,7 @@ class User:
         h=headers
         h.update({
             'Authorization' : 'OAuth="'+ self.oauth + '"',
-            'Content-Length':  53, #@TODO Figure out length calculation
+            'Content-Length':  '53', #@TODO Figure out length calculation
             'Content-Type'  : 'application/json'
             })
 


### PR DESCRIPTION
Creating the happn user object fails(Header value 53 must be of type str or bytes, not <type 'int'>) python request module doesnt accept non strings headers https://github.com/kennethreitz/requests/issues/3477
