### PR TITLE
Add 3 methods:

### DIFF
--- a/happn/happn.py
+++ b/happn/happn.py
@@ -224,7 +224,7 @@ class User:
             'Content-Type'  : 'application/json',
         })
         #@TODO Trim query to just distance request
-        query='{"fields":"id,first_name,gender,last_name,birth_date,login,workplace,distance"}'
+        query='{"fields":"spotify_tracks,modification_date,my_relations,social_synchronization.fields(facebook.fields(id),instagram.fields(pictures.fields(id),username)),school,age,clickable_profile_link,is_invited,type,gender,is_charmed,picture.fields(id,url,is_default).height(92).mode(0).width(92),last_meet_position,profiles.fields(id,url,is_default).height(1136).mode(1).width(640),has_charmed_me,job,first_name,last_invite_received,distance,availability,about,id,workplace,is_accepted"}'
         url = 'https://api.happn.fr/api/users/' + str(userID) + '?' + urllib2.quote(query)
 
         try:
@@ -237,7 +237,117 @@ class User:
             logging.info('Sybil %d m from target',self.distance)
         else:
             raise HTTP_MethodError(httpErrors[r.status_code])
+    
+    def get_targetinfo(self, userID):
+        """ Fetches userInfo for target userid
+            :param userID User ID of target user.
 
+            Returns dictionary packed with:
+                user id, facebook id, twitter id (not implemented), first name, last name,
+                birth date, login (nulled), workplace, distance
+        """
+        h={ #For some reason header update doesnt work
+            'http.useragent' : 'Happn/1.0 AndroidSDK/0',
+            'Authorization'  : 'OAuth="' + self.oauth+'"',
+            'Content-Type'   : 'application/json',
+            'User-Agent'     : 'happn/1292 CFNetwork/811.5.4 Darwin/16.6.0',
+            'Host'           : 'api.happn.fr',
+            'Connection'     : 'Keep-Alive',
+            'Accept-Encoding': 'gzip,deflate'
+        }
+
+        query = '?fields=spotify%5Ftracks%2Cmodification%5Fdate%2Cmy%5Frelations%2Csocial%5Fsynchronization%2Efields%28facebook%2Efields%28id%29%2Cinstagram%2Efields%28pictures%2Efields%28id%29%2Cusername%29%29%2Cschool%2Cage%2Cclickable%5Fprofile%5Flink%2Cis%5Finvited%2Ctype%2Cgender%2Cis%5Fcharmed%2Cpicture%2Efields%28id%2Curl%2Cis%5Fdefault%29%2Eheight%2892%29%2Emode%280%29%2Ewidth%2892%29%2Clast%5Fmeet%5Fposition%2Cprofiles%2Efields%28id%2Curl%2Cis%5Fdefault%29%2Eheight%281136%29%2Emode%281%29%2Ewidth%28640%29%2Chas%5Fcharmed%5Fme%2Cjob%2Cfirst%5Fname%2Clast%5Finvite%5Freceived%2Cdistance%2Cavailability%2Cabout%2Cid%2Cworkplace%2Cis%5Faccepted'
+        
+        url = 'https://api.happn.fr/api/users/' + userID + query
+        try:
+            r = requests.get(url, headers=h)
+        except Exception as e:
+            raise HTTP_MethodError('Error Connecting to Happn Server: {}'.format(e))
+
+        # Check if successful
+        if r.status_code == 200: #200 = 'OK'
+            # Load response into a python dictionary, syntax seems redundant
+            logging.debug("Retrieved info of user {}".format(userID))
+            return json.loads(json.dumps(r.json()['data'], sort_keys=True, indent=4, separators=(',', ': ')))
+            
+        else:
+            raise HTTP_MethodError(httpErrors[r.status_code])
+    
+    def get_conversations(self, offset=0,limit=64):
+        """ Get conversations with userID from Happn server
+            :param userID User ID of target user.
+            :param offset Offset of conversations to recieve
+            :param limit Number of conversations to recieve
+        """
+        
+        # Create and send HTTP Get to Happn server
+        h={ #For some reason header update doesnt work
+            'http.useragent' : 'Happn/1.0 AndroidSDK/0',
+            'Authorization'  : 'OAuth="' + self.oauth+'"',
+            'Content-Type'   : 'application/json',
+            'User-Agent'     : 'Happn/19.1.0 AndroidSDK/19',
+            'Host'           : 'api.happn.fr',
+            'Connection'     : 'Keep-Alive',
+            'Accept-Encoding': 'gzip, deflate'
+        }
+        query ='fields=creation%5Fdate%2Cparticipants%2Efields%28user%2Efields%28picture%2Efields%28id%2Curl%2Cis%5Fdefault%29%2Eheight%28120%29%2Emode%280%29%2Ewidth%28120%29%2Cage%2Cclickable%5Fmessage%5Flink%2Cid%2Cfirst%5Fname%2Cis%5Fmoderator%29%29%2Cmodification%5Fdate%2Cid%2Cmessages%2Efields%28sender%2Efields%28id%2Cfirst%5Fname%29%2Ccreation%5Fdate%2Cmessage%2Cid%29%2Eoffset%280%29%2Elimit%283%29%2Cis%5Fread&offset=' + str(offset) + '&limit=' + str(limit)
+        #'{"fields":"creation_date,participants.fields(user.fields(picture.fields(id,url,is_default).height(120).mode(0).width(120),age,clickable_message_link,id,first_name,is_moderator)),modification_date,id,messages.fields(sender.fields(id,first_name),creation_date,message,id).offset(0).limit(3),is_read", "offset": '+str(offset)+'}'
+        
+        url = 'https://api.happn.fr/api/users/' + str(self.id) + '/conversations?' + urllib2.quote(query)
+        
+        logging.debug("Using url = {}".format(url))
+        logging.debug("SenderID: {}".format(self.id))
+        
+        try:
+            r = requests.get(url, headers=h)
+        except Exception as e:
+            raise HTTP_MethodError('Error Connecting to Happn Server: {}'.format(e))
+            
+        if r.status_code == 200: #200 = 'OK'
+            logging.debug("Return code: {}".format(r.status_code))
+            return json.loads(json.dumps(r.json()['data'], sort_keys=True, indent=4, separators=(',', ': ')))
+        else:
+            logging.warn("Error: {}".format(r.status_code))
+            raise HTTP_MethodError(httpErrors[r.status_code])
+            
+    def get_messages(self, conversationID, offset=0,limit=64):
+        """ Get conversations with userID from Happn server
+            :param conversationID ID of conversation between user1 and user2.
+            :param offset Offset of messages to recieve
+            :param limit Number of messages to recieve
+        """
+        
+        # Create and send HTTP Get to Happn server
+        h={ #For some reason header update doesnt work
+            'http.useragent' : 'Happn/1.0 AndroidSDK/0',
+            'Authorization'  : 'OAuth="' + self.oauth+'"',
+            'Content-Type'   : 'application/json',
+            'User-Agent'     : 'Happn/19.1.0 AndroidSDK/19',
+            'Host'           : 'api.happn.fr',
+            'Connection'     : 'Keep-Alive',
+            'Accept-Encoding': 'gzip, deflate'
+        }
+        query = '{fields":"sender.fields(picture.fields(id,url,is_default).height(70).mode(0).width(70),clickable_message_link,id,first_name,is_moderator),creation_date,message,id"}'
+        
+        #fields=sender%2Efields%28picture%2Efields%28id%2Curl%2Cis%5Fdefault%29%2Eheight%2870%29%2Emode%280%29%2Ewidth%2870%29%2Cclickable%5Fmessage%5Flink%2Cid%2Cfirst%5Fname%2Cis%5Fmoderator%29%2Ccreation%5Fdate%2Cmessage%2Cid&offset=0&limit=27
+        
+        url = 'https://api.happn.fr/api/conversations/' + str(conversationID) + '/messages?' + urllib2.quote(query) + "%offset="+str(offset)+"&limit="+str(limit)
+        #
+        logging.debug("Using url = {}".format(url))
+        logging.debug("convoID: {}".format(conversationID))
+        
+        try:
+            r = requests.get(url, headers=h)
+        except Exception as e:
+            raise HTTP_MethodError('Error Connecting to Happn Server: {}'.format(e))
+            
+        if r.status_code == 200: #200 = 'OK'
+            logging.debug("Return code: {}".format(r.status_code))
+            return json.loads(json.dumps(r.json()['data'], sort_keys=True, indent=4, separators=(',', ': ')))
+        else:
+            logging.warn("Error: {}".format(r.status_code))
+            raise HTTP_MethodError(httpErrors[r.status_code])
+    
     def get_oauth(self):
         """ Gets the OAuth tokens using Happn's API """
 


### PR DESCRIPTION
-- get_targetinfo: returns info about target user. However, I have noticed that the distance parameter is None, contrary to in the real client. Maybe I'm doing somethign wrong or they have 'shadowbanned' that field because our api is not perfect.

-- get_conversations: returns the conversations that each user has

-- get_messages: returns messages when you supply a conversation_id to this function. You can get conversation_id from the above function. However, also here I have seen that the 'message' field under 'data'->sender->messages is missing. Maybe also a shadowban or something.

So your mileage may vary. Or maybe you have better luck than me...

When I looked at the requests with a MITM proxy I saw that the message content was present, however I cannot see that same content when I print out what I return from the python api. This is weird because I remember I had this working earlier.